### PR TITLE
Add CakePHP

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A curated list of amazingly awesome awesomeness
 	- [OCaml](https://github.com/rizo/awesome-ocaml)
 	- [Perl](https://github.com/hachiojipm/awesome-perl)
 	- [PHP](https://github.com/ziadoz/awesome-php)
+		- [CakePHP](https://github.com/dereuromark/awesome-cakephp)
 	- Python
 		- [by @svaksha](https://github.com/svaksha/pythonidae)
 		- [by @vinta](https://github.com/vinta/awesome-python)


### PR DESCRIPTION
Add Awesome CakePHP.
This should be a sub-element of PHP - to list frameworks and such.

CakePHP as one of the most mature and longest ones around should for sure be in there.
Especially since vanilla PHP programming alone becomes less and less each day (for a reason) and frameworks are used more and more (and use those PHP vanilla libraries as dependencies).
So in total PHP programming becomes actually even way more each day then. The segmentation simply shifts.
