### PR TITLE
Fix formatting for Common Lisp links

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A curated list of amazingly awesome awesomeness.
 		- [by @razum2um](https://github.com/razum2um/awesome-clojure)
 	- [ColdFusion](https://github.com/seancoyne/awesome-coldfusion)
 	- Common Lisp
-	        - [Common Lisp Libraries](https://github.com/CodyReichert/awesome-cl)
+		- [Common Lisp Libraries](https://github.com/CodyReichert/awesome-cl)
 		- [Learning Common Lisp](https://github.com/GustavBertram/awesome-common-lisp-learning-list)
 	- [Crystal](https://github.com/veelenga/awesome-crystal)
 	- [D](https://github.com/zhaopuming/awesome-d)


### PR DESCRIPTION
Sorry, I noticed the markup doesn't align correctly. I've changed it over to tabs instead of spaces, and I checked it in the preview before submitting.

**Not a contribution, just a formatting fix.**